### PR TITLE
 Add support for ed25519 encrypted signing keys 

### DIFF
--- a/image/image.go
+++ b/image/image.go
@@ -60,6 +60,7 @@ const (
 	IMAGE_TLV_ECDSA224 = 0x21
 	IMAGE_TLV_ECDSA256 = 0x22
 	IMAGE_TLV_RSA3072  = 0x23
+	IMAGE_TLV_ED25519  = 0x24
 	IMAGE_TLV_ENC_RSA  = 0x30
 	IMAGE_TLV_ENC_KEK  = 0x31
 )
@@ -71,6 +72,7 @@ var imageTlvTypeNameMap = map[uint8]string{
 	IMAGE_TLV_ECDSA224: "ECDSA224",
 	IMAGE_TLV_ECDSA256: "ECDSA256",
 	IMAGE_TLV_RSA3072:  "RSA3072",
+	IMAGE_TLV_ED25519:  "ED25519",
 	IMAGE_TLV_ENC_RSA:  "ENC_RSA",
 	IMAGE_TLV_ENC_KEK:  "ENC_KEK",
 }
@@ -142,7 +144,8 @@ func ImageTlvTypeIsSig(tlvType uint8) bool {
 	return tlvType == IMAGE_TLV_RSA2048 ||
 		tlvType == IMAGE_TLV_RSA3072 ||
 		tlvType == IMAGE_TLV_ECDSA224 ||
-		tlvType == IMAGE_TLV_ECDSA256
+		tlvType == IMAGE_TLV_ECDSA256 ||
+		tlvType == IMAGE_TLV_ED25519
 }
 
 func ImageTlvTypeIsSecret(tlvType uint8) bool {

--- a/sec/pkcs.go
+++ b/sec/pkcs.go
@@ -78,7 +78,6 @@ type hashFunc func() hash.Hash
 
 func parseEncryptedPrivateKey(der []byte) (key interface{}, err error) {
 	var wrapper pkcs5
-	fmt.Printf("unmarshalling %v\n", der)
 	if _, err = asn1.Unmarshal(der, &wrapper); err != nil {
 		return nil, err
 	}
@@ -153,7 +152,17 @@ func unwrapPbes2Pbkdf2(param *pbkdf2Param, size int, iv []byte, hashNew hashFunc
 		return nil, err
 	}
 
-	return x509.ParsePKCS8PrivateKey(plain)
+	privKey, err := x509.ParsePKCS8PrivateKey(plain)
+	if err != nil {
+		var _privKey interface{}
+		_privKey, _err := ParseEd25519Pkcs8(plain)
+		// If this is not an ed25519 key, return
+		// error from x509 parser
+		if _err == nil {
+			return _privKey, _err
+		}
+	}
+	return privKey, err
 }
 
 // Verify that PKCS#7 padding is correct on this plaintext message.

--- a/sec/util.go
+++ b/sec/util.go
@@ -5,6 +5,7 @@ import (
 	"encoding/pem"
 
 	"github.com/apache/mynewt-artifact/errors"
+	"golang.org/x/crypto/ed25519"
 )
 
 func parsePubPemKey(data []byte) (interface{}, error) {
@@ -21,7 +22,21 @@ func parsePubPemKey(data []byte) (interface{}, error) {
 
 	itf, err := x509.ParsePKIXPublicKey(p.Bytes)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error parsing public key")
+		// Not x509; assume ed25519.
+		pkix, err := unmarshalEd25519(p.Bytes)
+		if err != nil {
+			return nil, errors.Errorf(
+				"error parsing public key: unrecognized format")
+		}
+
+		if len(pkix.BitString.Bytes) != ed25519.PublicKeySize {
+			return nil, errors.Errorf(
+				"error parsing public key: "+
+					"ed25519 public key has wrong size: have=%d want=%d",
+				len(pkix.BitString.Bytes), ed25519.PublicKeySize)
+		}
+
+		itf = ed25519.PublicKey(pkix.BitString.Bytes)
 	}
 
 	return itf, nil


### PR DESCRIPTION
This is almost a straight copy of code from the newt repo, written by utzig@apache.org.