### PR TITLE
mfg: Verify embedded images separately

### DIFF
--- a/image/verify.go
+++ b/image/verify.go
@@ -155,14 +155,14 @@ func (img *Image) VerifySigs(keys []sec.PubSignKey) (int, error) {
 		return -1, err
 	}
 
-	for _, k := range keys {
-		idx, err := sec.VerifySigs(k, sigs, hash)
+	for keyIdx, k := range keys {
+		sigIdx, err := sec.VerifySigs(k, sigs, hash)
 		if err != nil {
 			return -1, err
 		}
 
-		if idx != -1 {
-			return idx, nil
+		if sigIdx != -1 {
+			return keyIdx, nil
 		}
 	}
 


### PR DESCRIPTION
Prior to this commit, the `"mfg".Mfg.VerifyManifest()` function attempted to verify all of an mfg's embedded images.  This resulted in a clunky and unfriendly API:

* The caller was required to pass in a set of public signing keys and private encryption keys.
* There was no way to verify the manifest without also checking the embedded images.  E.g., if the caller doesn't have access to encryption keys, this function would fail even if the mfgimage is correct.

Now `VerifyManifest()` does not verify the embedded images.  To verify the embedded images, the caller should call `"mfg".Mfg.ExtractImages()` and call the image verification functions on each image separately.  
