### PR TITLE
Fix IMAGE_F_NON_BOOTABLE definition to match mcuboot

### DIFF
--- a/image/image.go
+++ b/image/image.go
@@ -46,8 +46,8 @@ const (
  */
 const (
 	IMAGE_F_PIC          = 0x00000001
-	IMAGE_F_NON_BOOTABLE = 0x00000002 /* non bootable image */
 	IMAGE_F_ENCRYPTED    = 0x00000004 /* encrypted image */
+	IMAGE_F_NON_BOOTABLE = 0x00000010 /* non bootable image */
 )
 
 /*


### PR DESCRIPTION
This pulls in alvarop's change to newt:

> The correct flag for IMAGE_F_NON_BOOTABLE should be 0x10 instead of 0x02
> according to the mcuboot files:
> https://github.com/JuulLabs-OSS/mcuboot/blob/3c469bc698a9767859ed73cd0201c44161204d5c/boot/bootutil/include/bootutil/image.h#L46

Since this code is moving from `newt` to `artifact`, this commit needs to be pulled in.