### PR TITLE
New mfg manifest fields: target.extra, raw.extra

### DIFF
--- a/manifest/mfg_manifest.go
+++ b/manifest/mfg_manifest.go
@@ -30,18 +30,20 @@ import (
 )
 
 type MfgManifestTarget struct {
-	Name         string `json:"name"`
-	Offset       int    `json:"offset"`
-	BinPath      string `json:"bin_path,omitempty"`
-	ImagePath    string `json:"image_path,omitempty"`
-	HexPath      string `json:"hex_path,omitempty"`
-	ManifestPath string `json:"manifest_path"`
+	Name         string                 `json:"name"`
+	Offset       int                    `json:"offset"`
+	BinPath      string                 `json:"bin_path,omitempty"`
+	ImagePath    string                 `json:"image_path,omitempty"`
+	HexPath      string                 `json:"hex_path,omitempty"`
+	ManifestPath string                 `json:"manifest_path"`
+	Extra        map[string]interface{} `json:"extra,omitempty"`
 }
 
 type MfgManifestRaw struct {
-	Filename string `json:"filename"`
-	Offset   int    `json:"offset"`
-	BinPath  string `json:"bin_path"`
+	Filename string                 `json:"filename"`
+	Offset   int                    `json:"offset"`
+	BinPath  string                 `json:"bin_path"`
+	Extra    map[string]interface{} `json:"extra,omitempty"`
 }
 
 type MfgManifestMetaMmr struct {

--- a/manifest/mfg_manifest.go
+++ b/manifest/mfg_manifest.go
@@ -38,6 +38,12 @@ type MfgManifestTarget struct {
 	ManifestPath string `json:"manifest_path"`
 }
 
+type MfgManifestRaw struct {
+	Filename string `json:"filename"`
+	Offset   int    `json:"offset"`
+	BinPath  string `json:"bin_path"`
+}
+
 type MfgManifestMetaMmr struct {
 	Area      string `json:"area"`
 	Device    int    `json:"_device"`
@@ -72,6 +78,7 @@ type MfgManifest struct {
 	FlashAreas []flash.FlashArea `json:"flash_map"`
 
 	Targets []MfgManifestTarget `json:"targets"`
+	Raws    []MfgManifestRaw    `json:"raws"`
 	Meta    *MfgManifestMeta    `json:"meta,omitempty"`
 }
 


### PR DESCRIPTION
Add a new field to the `target` and `raw` mfg manifest items: `extra_manifest`.  This field is a generic map that gets passed through from the mfg definition.  This field is useful if the user needs to convey additional information to some system that knows how to parse a manufacturing manifest file.