### PR TITLE
Parse protected TLVs when parsing an image

### DIFF
--- a/image/map.go
+++ b/image/map.go
@@ -81,6 +81,12 @@ func (img *Image) Map() (map[string]interface{}, error) {
 	}
 	m["tlvs"] = tlvMaps
 
+	protTlvMaps := []map[string]interface{}{}
+	for i, tlv := range img.ProtTlvs {
+		protTlvMaps = append(protTlvMaps, tlv.Map(i, offs.ProtTlvs[i]))
+	}
+	m["prot_tlvs"] = protTlvMaps
+
 	return m, nil
 }
 


### PR DESCRIPTION
Prior to this commit, when parsing an image that had protected TLVs:
* The protected TLVs were interpreted as normal TLVs.
* The normal TLVs were ignored.