### PR TITLE
Add support for image encryption using ECIES-P256

### DIFF
--- a/image/create.go
+++ b/image/create.go
@@ -129,6 +129,8 @@ func GenerateEncTlv(cipherSecret []byte) (ImageTlv, error) {
 
 	if len(cipherSecret) == 256 {
 		encType = IMAGE_TLV_ENC_RSA
+	} else if len(cipherSecret) == 113 {
+		encType = IMAGE_TLV_ENC_EC256
 	} else if len(cipherSecret) == 24 {
 		encType = IMAGE_TLV_ENC_KEK
 	} else {

--- a/image/image.go
+++ b/image/image.go
@@ -64,6 +64,7 @@ const (
 	IMAGE_TLV_ED25519   = 0x24
 	IMAGE_TLV_ENC_RSA   = 0x30
 	IMAGE_TLV_ENC_KEK   = 0x31
+	IMAGE_TLV_ENC_EC256 = 0x32
 	IMAGE_TLV_AES_NONCE = 0x50
 	IMAGE_TLV_SECRET_ID = 0x60
 )
@@ -78,6 +79,7 @@ var imageTlvTypeNameMap = map[uint8]string{
 	IMAGE_TLV_ED25519:   "ED25519",
 	IMAGE_TLV_ENC_RSA:   "ENC_RSA",
 	IMAGE_TLV_ENC_KEK:   "ENC_KEK",
+	IMAGE_TLV_ENC_EC256: "ENC_EC256",
 	IMAGE_TLV_AES_NONCE: "AES_NONCE",
 	IMAGE_TLV_SECRET_ID: "SEC_KEY_ID",
 }
@@ -171,7 +173,8 @@ func ImageTlvTypeIsSig(tlvType uint8) bool {
 
 func ImageTlvTypeIsSecret(tlvType uint8) bool {
 	return tlvType == IMAGE_TLV_ENC_RSA ||
-		tlvType == IMAGE_TLV_ENC_KEK
+		tlvType == IMAGE_TLV_ENC_KEK ||
+		tlvType == IMAGE_TLV_ENC_EC256
 }
 
 func (ver ImageVersion) String() string {


### PR DESCRIPTION
This adds support for encrypting images using ECIES-P256. The MCUBoot
implementation was described here: https://github.com/JuulLabs-OSS/mcuboot/blob/master/docs/encrypted_images.md#ecies-p256-encryption

This only adds the infrastructure required by `newt` to create encrypted images. `imgmod` dependencies were not added.