### PR TITLE
mfg_manifest: Add list of flash device names

### DIFF
--- a/manifest/mfg_manifest.go
+++ b/manifest/mfg_manifest.go
@@ -80,6 +80,7 @@ type MfgManifest struct {
 	EraseVal   byte              `json:"erase_val"`
 	Signatures []MfgManifestSig  `json:"signatures,omitempty"`
 	FlashAreas []flash.FlashArea `json:"flash_map"`
+	FlashNames []string          `json:"flash_names",omitempty`
 
 	Targets []MfgManifestTarget `json:"targets"`
 	Raws    []MfgManifestRaw    `json:"raws"`


### PR DESCRIPTION
Allow an mfgimage manifest to indicate the names of the BSP's flash devices.
