### PR TITLE
Fix FindProtTlv functions: were returning reg TLVs

### DIFF
--- a/image/image.go
+++ b/image/image.go
@@ -342,7 +342,7 @@ func (img *Image) FindProtTlvsIf(pred func(tlv ImageTlv) bool) []*ImageTlv {
 
 	idxs := img.FindProtTlvIndicesIf(pred)
 	for _, idx := range idxs {
-		tlvs = append(tlvs, &img.Tlvs[idx])
+		tlvs = append(tlvs, &img.ProtTlvs[idx])
 	}
 
 	return tlvs
@@ -354,7 +354,7 @@ func (img *Image) FindProtTlvs(tlvType uint8) []*ImageTlv {
 
 	idxs := img.FindProtTlvIndices(tlvType)
 	for _, idx := range idxs {
-		tlvs = append(tlvs, &img.Tlvs[idx])
+		tlvs = append(tlvs, &img.ProtTlvs[idx])
 	}
 
 	return tlvs


### PR DESCRIPTION
The `Image#FindProtTlv` functions were returning TLVs from the regular list, not the protected list!