### PR TITLE
image: During parsing, account for header padding

### DIFF
--- a/image/parse.go
+++ b/image/parse.go
@@ -208,7 +208,7 @@ func ParseImage(imgData []byte) (Image, error) {
 	}
 	offset += size
 
-	totalLen := IMAGE_HEADER_SIZE + len(body) + int(trailer.TlvTotLen)
+	totalLen := int(hdr.HdrSz) + len(body) + int(trailer.TlvTotLen)
 	if protTrailer != nil {
 		totalLen += int(protTrailer.TlvTotLen)
 	}


### PR DESCRIPTION
The ParseImage function was ignoring header padding.  For images with header padding, this function truncated the image.