### PR TITLE
image: Try ALL enc keys when verifying hash

### DIFF
--- a/image/verify.go
+++ b/image/verify.go
@@ -123,12 +123,12 @@ func (img *Image) VerifyHash(privEncKeys []sec.PrivEncKey) (int, error) {
 	for i, key := range privEncKeys {
 		dec, err := Decrypt(*img, key)
 		if err != nil {
-			return -1, err
-		}
-
-		hashErr = dec.verifyHashDecrypted()
-		if hashErr == nil {
-			return i, nil
+			hashErr = err
+		} else {
+			hashErr = dec.verifyHashDecrypted()
+			if hashErr == nil {
+				return i, nil
+			}
 		}
 	}
 


### PR DESCRIPTION
Before this PR, the image verification procedure would fail early if decryption failed.  The procedure is supposed to try all the keys and report success if any of them works.