### PR TITLE
image: calculate padding when parsing image

### DIFF
--- a/image/parse.go
+++ b/image/parse.go
@@ -239,6 +239,11 @@ func ParseImage(imgData []byte) (Image, error) {
 	img.Tlvs = tlvs
 	img.ProtTlvs = protTlvs
 
+	extra := img.Header.HdrSz - IMAGE_HEADER_SIZE
+	if extra > 0 {
+		img.Pad = make([]byte, extra)
+	}
+
 	return img, nil
 }
 


### PR DESCRIPTION
When parsing an image file, if the image indicates an extra-long header, build a slice of bytes to hold the extra leading padding.  This is needed to perform the image hash calculation correctly.