### PR TITLE
manifest: Add `MfgManifestTarget.Size` field

### DIFF
--- a/manifest/mfg_manifest.go
+++ b/manifest/mfg_manifest.go
@@ -32,6 +32,7 @@ import (
 type MfgManifestTarget struct {
 	Name         string                 `json:"name"`
 	Offset       int                    `json:"offset"`
+	Size         int                    `json:"size"`
 	BinPath      string                 `json:"bin_path,omitempty"`
 	ImagePath    string                 `json:"image_path,omitempty"`
 	HexPath      string                 `json:"hex_path,omitempty"`


### PR DESCRIPTION
This field indicates the size of the target binary (either .bin or .img file).  This is useful for splitting an mfgimage into its constituent parts.  Without this change, the only method of doing this is to use a heuristic: remove all 0xff bytes from the end of each part (this is what `imgmod mfg split` does).  However, this leads to problems if a target or raw entry happens to contain trailing 0xff bytes.