### PR TITLE
Functions to decrypt hw-encrypted images

### DIFF
--- a/image/create.go
+++ b/image/create.go
@@ -487,8 +487,6 @@ func (ic *ImageCreator) Create() (Image, error) {
 
 	img.Header.ProtSz = calcProtSize(img.ProtTlvs)
 
-	payload := &ic.Body
-
 	// Followed by data.
 	if ic.PlainSecret != nil {
 		encBody, err := sec.EncryptAES(ic.Body, ic.PlainSecret, ic.Nonce)
@@ -496,16 +494,11 @@ func (ic *ImageCreator) Create() (Image, error) {
 			return img, err
 		}
 		img.Body = append(img.Body, encBody...)
-
-		if ic.HWKeyIndex >= 0 {
-			payload = &encBody
-		}
-
 	} else {
 		img.Body = append(img.Body, ic.Body...)
 	}
 
-	hashBytes, err := calcHash(ic.InitialHash, img.Header, img.Pad, *payload, img.ProtTlvs)
+	hashBytes, err := img.CalcHash(ic.InitialHash)
 	if err != nil {
 		return img, err
 	}

--- a/image/image.go
+++ b/image/image.go
@@ -475,9 +475,10 @@ func (i *Image) Hash() ([]byte, error) {
 	return tlv.Data, nil
 }
 
-// CalcHash calculates a SHA256 of the given image.
-func (i *Image) CalcHash() ([]byte, error) {
-	return calcHash(nil, i.Header, i.Pad, i.Body, i.ProtTlvs)
+// CalcHash calculates a SHA256 of the given image.  initialHash should be nil
+// for non-split-images.
+func (i *Image) CalcHash(initialHash []byte) ([]byte, error) {
+	return calcHash(initialHash, i.Header, i.Pad, i.Body, i.ProtTlvs)
 }
 
 // WritePlusOffsets writes a binary image to the given writer.  It returns

--- a/image/verify.go
+++ b/image/verify.go
@@ -35,7 +35,7 @@ func (img *Image) verifyHashDecrypted() error {
 		return err
 	}
 
-	wantHash, err := img.CalcHash()
+	wantHash, err := img.CalcHash(nil)
 	if err != nil {
 		return err
 	}

--- a/manifest/mfg_manifest.go
+++ b/manifest/mfg_manifest.go
@@ -148,6 +148,22 @@ func (m *MfgManifest) FindFlashAreaDevOff(device int, offset int) *flash.FlashAr
 	return nil
 }
 
+// FindWithinFlashAreaDevOff searches an mfg manifest for a flash area with the
+// specified device that contains the given offset.
+func (m *MfgManifest) FindWithinFlashAreaDevOff(device int, offset int) *flash.FlashArea {
+	for i, _ := range m.FlashAreas {
+		fa := &m.FlashAreas[i]
+		if fa.Device == device {
+			end := fa.Offset + fa.Size
+			if offset >= offset && offset < end {
+				return fa
+			}
+		}
+	}
+
+	return nil
+}
+
 // FindFlashAreaName searches an mfg manifest for a flash area with the
 // specified name.
 func (m *MfgManifest) FindFlashAreaName(name string) *flash.FlashArea {


### PR DESCRIPTION
"Hardware-encrypted images" are images that run on devices capable of on-the-fly decryption.  These images differ from regular encrypted images in the following ways: 

* Contain some extra TLVs (nonce, secret ID)
* The hash is of the *encrypted* image