### PR TITLE
FindWithinFlashAreaDevOff: Fix bad compare

### DIFF
--- a/manifest/mfg_manifest.go
+++ b/manifest/mfg_manifest.go
@@ -155,7 +155,7 @@ func (m *MfgManifest) FindWithinFlashAreaDevOff(device int, offset int) *flash.F
 		fa := &m.FlashAreas[i]
 		if fa.Device == device {
 			end := fa.Offset + fa.Size
-			if offset >= offset && offset < end {
+			if offset >= fa.Offset && offset < end {
 				return fa
 			}
 		}


### PR DESCRIPTION
This function was broken due to a typo in a comparison.