### PR TITLE
sec: Fix infinite loop

### DIFF
--- a/sec/encrypt.go
+++ b/sec/encrypt.go
@@ -263,7 +263,7 @@ func EncryptAES(plain []byte, secret []byte, nonce []byte) ([]byte, error) {
 
 	iv := nonce
 	for len(iv) < 16 {
-		iv = append(nonce, 0)
+		iv = append(iv, 0)
 	}
 
 	stream := cipher.NewCTR(blk, iv)


### PR DESCRIPTION
If the caller of EncryptAES() supplied a nonce shorter than 16 bytes, the function would enter an endless loop.