### PR TITLE
Allow "extra" information in a manifest

### DIFF
--- a/image/create.go
+++ b/image/create.go
@@ -52,15 +52,16 @@ type ImageCreator struct {
 }
 
 type ImageCreateOpts struct {
-	SrcBinFilename    string
-	SrcEncKeyFilename string
-	SrcEncKeyIndex    int
-	Version           ImageVersion
-	SigKeys           []sec.PrivSignKey
-	Sections          []Section
-	LoaderHash        []byte
-	HdrPad            int
-	ImagePad          int
+	SrcBinFilename           string
+	SrcEncKeyFilename        string
+	SrcEncKeyIndex           int
+	SrcExtraManifestFilename string
+	Version                  ImageVersion
+	SigKeys                  []sec.PrivSignKey
+	Sections                 []Section
+	LoaderHash               []byte
+	HdrPad                   int
+	ImagePad                 int
 }
 
 type ECDSASig struct {
@@ -154,17 +155,17 @@ func GenerateEncTlv(cipherSecret []byte) (ImageTlv, error) {
 
 // GenerateEncTlv creates an encryption-secret TLV given a secret.
 func GenerateSectionTlv(section Section) (ImageTlv, error) {
-	data := make([]byte, 8 + len(section.Name))
+	data := make([]byte, 8+len(section.Name))
 
 	binary.LittleEndian.PutUint32(data[0:], uint32(section.Offset))
 	binary.LittleEndian.PutUint32(data[4:], uint32(section.Size))
 	copy(data[8:], section.Name)
 
-	return ImageTlv {
+	return ImageTlv{
 		Header: ImageTlvHdr{
 			Type: IMAGE_TLV_SECTION,
-			Pad: 0,
-			Len: uint16(len(data)),
+			Pad:  0,
+			Len:  uint16(len(data)),
 		},
 		Data: data,
 	}, nil

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -64,19 +64,20 @@ type ManifestRepo struct {
 }
 
 type Manifest struct {
-	Name       string            `json:"name"`
-	Date       string            `json:"build_time"`
-	Version    string            `json:"build_version"`
-	BuildID    string            `json:"id"`
-	Image      string            `json:"image"`
-	ImageHash  string            `json:"image_hash"`
-	Loader     string            `json:"loader"`
-	LoaderHash string            `json:"loader_hash"`
-	Pkgs       []*ManifestPkg    `json:"pkgs"`
-	LoaderPkgs []*ManifestPkg    `json:"loader_pkgs,omitempty"`
-	TgtVars    []string          `json:"target"`
-	Repos      []*ManifestRepo   `json:"repos"`
-	Syscfg     map[string]string `json:"syscfg"`
+	Name       string                 `json:"name"`
+	Date       string                 `json:"build_time"`
+	Version    string                 `json:"build_version"`
+	BuildID    string                 `json:"id"`
+	Image      string                 `json:"image"`
+	ImageHash  string                 `json:"image_hash"`
+	Loader     string                 `json:"loader"`
+	LoaderHash string                 `json:"loader_hash"`
+	Pkgs       []*ManifestPkg         `json:"pkgs"`
+	LoaderPkgs []*ManifestPkg         `json:"loader_pkgs,omitempty"`
+	TgtVars    []string               `json:"target"`
+	Repos      []*ManifestRepo        `json:"repos"`
+	Syscfg     map[string]string      `json:"syscfg"`
+	Extra      map[string]interface{} `json:"extra"`
 
 	PkgSizes       []*ManifestSizePkg `json:"pkgsz"`
 	LoaderPkgSizes []*ManifestSizePkg `json:"loader_pkgsz,omitempty"`


### PR DESCRIPTION
"extra" is a map of key-value pairs supplied by individual packages in a build.