### PR TITLE
Remove ec256 ASN1 signature padding

### DIFF
--- a/image/create.go
+++ b/image/create.go
@@ -224,9 +224,6 @@ func GenerateSigEc(key sec.PrivSignKey, hash []byte) ([]byte, error) {
 		return nil, errors.Errorf("signature truncated")
 	}
 
-	pad := make([]byte, int(sigLen)-len(signature))
-	signature = append(signature, pad...)
-
 	return signature, nil
 }
 


### PR DESCRIPTION
Old MCUboot releases required the ASN1 of ec256 signatures to be padded; this was removed with:

https://github.com/mcu-tools/mcuboot/pull/680

After this change, it is possible to build EC-256 based signature validation using Mbed TLS. This commit removes the padding and should allow following releases to use Mbed TLS, instead of Tinycrypt.

Related to https://github.com/apache/mynewt-newt/issues/450