### PR TITLE
Integration with Github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,4 @@
+#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -14,18 +15,26 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+#
 
-language: go
+name: Build and test
 
-go:
-  - "1.x"
+on: [push, pull_request]
 
-env:
-  - GO111MODULE=on
-
-before_script:
-  - printenv
-  - go version
-
-script:
-  - go test -v ./...
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 'stable'
+      - name: Run tests
+        shell: bash
+        run: |
+             go version
+             go test -v ./...


### PR DESCRIPTION
ASF moved away from Travis to Github Actions.